### PR TITLE
Improving OMERO sections from feedback

### DIFF
--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -12,7 +12,7 @@ title: Getting Started
         <hr class="whitespace">
         <div class="row">
             <div class="medium-12 small-centered columns ">
-                <h4 class="subheader">Whether you’re a new user with an institutional OMERO.server looking for help getting started, a developer wanting to read up on the nuts and bolts, or a system administrator wanting to install an OMERO.server, you’ll find the information you need by following the links below.</h4>
+                <h4 class="subheader">TO DO: rewrite content to highlight some quick access paths for different user types e.g. IDR and demo, Fiji for scientists, docker for devs, public institutional repos </h4>
             </div>
         </div>        
         <!-- end intro section -->

--- a/products/omero/developers/getting-started.html
+++ b/products/omero/developers/getting-started.html
@@ -8,7 +8,7 @@ usergroup: Developers
         <hr class="whitespace">        
         <div class="row column text-center">
             <h3>Getting Started</h3>
-            <h5 class="subheader">Getting up and running with OMERO is easy with our extensive documentation. Some sections which may be particularly relevant to developers new to the project are highlighted here.</h5>
+            <h5 class="subheader">TO DO: replace content with some steps and example code inspired by https://zeroc.com</h5>
         </div>       
         <hr>        
         <div class="row small-up-3 large-up-3">
@@ -23,30 +23,6 @@ usergroup: Developers
                 <h5>Installing OMERO from source</h5>
                 <p>This page provides links to the source code and further information on working with it via Git and GitHub and how to build OMERO.</p>
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/installation.html" target="_blank">Read the Guide</a>
-            </div>
-            <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
-                <h5>Working with the Command Line Interface</h5>
-                <p>This section gives some handy tips and pointers to using the CLI to work with OMERO objects and writing plugins.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/cli/index.html" target="_blank">Read the Guide</a>
-            </div>
-            <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
-                <h5>Using the OMERO API</h5>
-                <p>This section of the documentation introduces working with OMERO in Python, Java, C++ and MATLAB.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/index.html#using-the-omero-api" target="_blank">Read the Guide</a>
-            </div>
-            <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
-                <h5>Introduction to OMERO.scripts</h5>
-                <p>This page introduces the scripting service, the OMERO version of plugins, and provides links to all the further information you need to get writing and managing your own scripts.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/scripts/index.html" target="_blank">Read the Guide</a>
-            </div>
-            <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
-                <h5>OMERO.web framework</h5>
-                <p>Developing an app for OMERO.web is a great way to add your own functionality. This page introduces the architecture of the web client and provides examples and links to further pages to help get you started.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/Web.html" target="_blank">Read the Guide</a>
             </div>
         </div>
         <!-- end Getting Started -->

--- a/products/omero/developers/index.html
+++ b/products/omero/developers/index.html
@@ -9,37 +9,50 @@ usergroup: Developers
         <div class="row column text-center">
             <h3>OMERO is designed to be extended and integrated with other tools</h3>
             <hr>
-            <h5 class="subheader">As an open source project, OMERO welcomes contributions from external developers. You are welcome to write your own client code or extend the server to suit your needs and there is a whole community and extensive documentation provided to support you. You can write in Java, Python, C++ or MATLAB to modify existing clients or the server, build your own custom clients or web apps, or develop scripts to run analysis on the server. All the code is available via GitHub and the API is public and documented.
+            <h5 class="subheader"><p>OMERO is an open source client/server system written in Java for visualizing, managing, and annotating microscope images and metadata. The OMERO API allows clients to be written in Java, Python, C++ or MATLAB. The OMERO platform includes a Java client OMERO.insight, a Python-based web client OMERO.web, a Command Line Interface which uses Python, and a Java ImageJ plugin. OMERO also supports a scripting service which allows Python scripts to be run on the server and called from any of the other clients.</p>
+                <p>You are welcome to write your own client code or scripts, or extend the server to suit your needs, and there is a whole community and extensive documentation to support you.</p>
             </h5>
             <img class="thumbnail" src="http://placehold.it/1000x300">
         </div>
         <!-- end Why Use OMERO -->
         
         <!-- begin Key Features -->
-        <hr class="whitespace">        
+        <hr class="whitespace">
         <div class="row column text-center">
             <h3>Key Features</h3>
-            <h5 class="subheader">The strength of OMERO lies in its in interoperability. Some of the key features which enable this are highlighted here.</h5>
+            <h5 class="subheader">The strength of OMERO lies in its interoperability. Some of the main extension points are highlighted below.</h5>
         </div>        
         <hr>        
         <div class="row small-up-2 large-up-4">
             <div class="column text-center">
                 <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
-                <h5>Open Source Software</h5>
-                <p>OME source code is available under the <a href="#">GNU General public license</a> or through commercial license from <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
-                <a class="button hollow tiny expanded" href="https://github.com/openmicroscopy" target="_blank">Contribute to the Code</a>
+                <h5>Open Source</h5>
+                <p>All OMERO source code is available under the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General public license</a> or through commercial license from <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
+                <a class="button hollow tiny expanded" href="https://github.com/openmicroscopy" target="_blank">Find us on GitHub</a>
             </div>
             <div class="column text-center">
                 <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
-                <h5>Extending OMERO</h5>
-                <p>Write your own Web and Java apps using the OMERO APIs, we have tips, tools and resources useful for working with the OMERO API.</p>
-                <a class="button hollow tiny expanded" href="http://www.openmicroscopy.org/site/support/omero/developers/GettingStarted.html" target="_blank">Get Started</a>
+                <h5>Public API</h5>
+                <p>Work with your data in Python, Java, MATLAB and C++.</p>
+                <a class="button hollow tiny expanded" href="http://www.openmicroscopy.org/site/support/omero/developers/index.html#using-the-omero-api" target="_blank">View Developer Guides</a>
             </div>
             <div class="column text-center">
                 <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
-                <h5>Python Blitz API</h5>
-                <p>The Python 'Blitz' Gateway provides an easy-to-use API for OMERO making it easier to work with your data in Python.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/Python.html" target="_blank">View Developer Guide</a>
+                <h5>OMERO.web</h5>
+                <p>Use the OMERO.web framework to build web applications for OMERO.</p>
+                <a class="button hollow tiny expanded" href="http://www.openmicroscopy.org/site/support/omero/developers/Web.html" target="_blank">View Developer Guide</a>
+            </div>
+            <div class="column text-center">
+                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <h5>OMERO clients</h5>
+                <p>Develop Blitz clients that use the API and the Ice remoting framework.</p>
+                <a class="button hollow tiny expanded" href="http://www.openmicroscopy.org/site/support/omero/developers/GettingStarted/AdvancedClientDevelopment.html" target="_blank">View Developer Guide</a>
+            </div>
+            <div class="column text-center">
+                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <h5>OMERO.cli</h5>
+                <p>Use the CLI to work with OMERO objects and write plugins.</p>
+                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/cli/index.html" target="_blank">View Developer Guide</a>
             </div>
             <div class="column text-center">
                 <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
@@ -49,9 +62,15 @@ usergroup: Developers
             </div>
             <div class="column text-center">
                 <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
-                <h5>Tabular Data Support</h5>
-                <p>HDF-based storage of measurement results with an API for exporting to Excel using OMERO.tables.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/analysis.html#storing-external-data-in-omero" target="_blank">View Developer Guide</a>
+                <h5>Analysis</h5>
+                <p>Save your analysis results to OMERO.server or use OMERO.tables to store columnar data.</p>
+                <a class="button hollow tiny expanded" href="http://www.openmicroscopy.org/site/support/omero/developers/index.html#analysis" target="_blank">View Developer Guide</a>
+            </div>
+            <div class="column text-center">
+                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <h5>OMERO.server</h5>
+                <p>Extend the OMERO.server by writing your own services or using the OMERO.grid infrastructure to manage your own processes.</p>
+                <a class="button hollow tiny expanded" href="http://www.openmicroscopy.org/site/support/omero/developers/Server/ExtendingOmero.html" target="_blank">View Developer Guide</a>
             </div>
         </div>
         <!-- end Key Features -->

--- a/products/omero/developers/index.html
+++ b/products/omero/developers/index.html
@@ -33,25 +33,25 @@ usergroup: Developers
                 <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
                 <h5>Extending OMERO</h5>
                 <p>Write your own Web and Java apps using the OMERO APIs, we have tips, tools and resources useful for working with the OMERO API.</p>
-                <a class="button hollow tiny expanded" href="http://www.openmicroscopy.org/site/support/omero5.2/developers/GettingStarted.html" target="_blank">Get Started</a>
+                <a class="button hollow tiny expanded" href="http://www.openmicroscopy.org/site/support/omero/developers/GettingStarted.html" target="_blank">Get Started</a>
             </div>
             <div class="column text-center">
                 <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
                 <h5>Python Blitz API</h5>
                 <p>The Python 'Blitz' Gateway provides an easy-to-use API for OMERO making it easier to work with your data in Python.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero5.2/developers/Python.html" target="_blank">View Developer Guide</a>
+                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/Python.html" target="_blank">View Developer Guide</a>
             </div>
             <div class="column text-center">
                 <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
                 <h5>Scripting Service</h5>
                 <p>Write Python scripts to add functionality to the OMERO.server. <a href="https://www.openmicroscopy.org/site/community/scripts" target="_blank">Share your scripts</a> with the community.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero5/developers/index.html#omero-scripts-plugins-for-omero" target="_blank">View Developer Guide</a>
+                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/index.html#omero-scripts-plugins-for-omero" target="_blank">View Developer Guide</a>
             </div>
             <div class="column text-center">
                 <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
                 <h5>Tabular Data Support</h5>
                 <p>HDF-based storage of measurement results with an API for exporting to Excel using OMERO.tables.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero5/developers/analysis.html#storing-external-data-in-omero" target="_blank">View Developer Guide</a>
+                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/analysis.html#storing-external-data-in-omero" target="_blank">View Developer Guide</a>
             </div>
         </div>
         <!-- end Key Features -->

--- a/products/omero/scientists/getting-started.html
+++ b/products/omero/scientists/getting-started.html
@@ -8,19 +8,19 @@ usergroup: Scientists
         <hr class="whitespace">        
         <div class="row column text-center">
             <h3>Getting Started</h3>
-            <h5 class="subheader">Getting started with OMERO is easy with our range of ‘How to’ guides. If you have an institutional server to connect to, you can get up and running in minutes. If OMERO is all new to you, we have a demo server you can try out.</h5>
+            <h5 class="subheader">Getting started with OMERO is easy with our range of ‘How to’ guides. If you have an institutional server to connect to, you can get up and running in minutes with a desktop or browser-based app. If OMERO is all new to your institution, we have a demo server you can try out.</h5>
         </div>       
         <hr>        
-        <div class="row small-up-3 large-up-3">
+        <div class="row small-up-2 large-up-2">
             <div class="column text-center">
                 <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
                 <h5>Try out the Demo server</h5>
-                <p><a href="http://qa.openmicroscopy.org.uk/registry/demo_account/" target="_blank">Register</a> and we’ll send you a log-in to try out OMERO before committing any IT resources to setting up your own server. This guide explains the terms of use and takes you through connecting to the server via the apps.</p>
+                <p><a href="http://qa.openmicroscopy.org.uk/registry/demo_account/" target="_blank">Register</a> and we’ll send you a log-in to try out OMERO before committing any IT resources to getting a server set up. This guide explains the terms of use and takes you through connecting to the server via the apps.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/demo-server.html" target="_blank">Read the Guide</a>
             </div>
             <div class="column text-center">
                 <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
-                <h5>Getting started with the desktop client</h5>
+                <h5>Getting started with the desktop app</h5>
                 <p>This guide covers downloading and installing the OMERO.insight desktop app, importing your images and getting to grips with the UI for browsing your data.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/getting-started-5.html" target="_blank">Read the Guide</a>
             </div>
@@ -35,18 +35,6 @@ usergroup: Scientists
                 <h5>Using ImageJ/Fiji with OMERO</h5>
                 <p>Already familiar with ImageJ/Fiji for image analysis? This guide gets you set up with the OMERO.insight-ij plugin so you can work with your data stored in OMERO.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/imagej.html" target="_blank">Read the Guide</a>
-            </div>
-            <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
-                <h5>Managing your data</h5>
-                <p>Metadata matters at OME. This guide covers organizing your data, editing names, adding tags and experimental metadata, attaching files and managing your user settings.</p>
-                <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/managing-data.html" target="_blank">Read the Guide</a>
-            </div>
-            <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
-                <h5>Designing figures</h5>
-                <p>Presenting is crucial; with OMERO.figure you can produce figures with labels, scale bars, custom colouring and layout, all linked to your raw data, making your process completely transparent for reviewers. This has been described by our users as “the killer app for OMERO”.</p>
-                <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/figure.html" target="_blank">Read the Guide</a>
             </div>
         </div>
         <!-- end Getting Started -->


### PR DESCRIPTION
This PR addresses further comments on https://trello.com/c/HMwCpF2I/472-understanding-our-users regarding making the split between the overview and getting started pages clearer and less repetitive of content.

Specifically it:
- cuts down the scientists getting started section to just the demo server and app intros and tries to make clearer the 'you need a server to connect to' point without making scientists think they need to install the server themselves
- rewrites the developer overview to be a more technical introduction similar to the developer docs index page
- Marks To Dos - rewrite developer getting started section and main Getting Started page to be more general 'OME stuff you can look at/try out now'

(WIP for now, will add info here)