### PR TITLE
Remove stars as events in the past now

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -16,13 +16,13 @@ meta_description: Learn how to use OMERO by attending one of our workshops.
             </div>
             <hr class="medium-8">
             <div class="small-12 medium-8 medium-offset-2 columns">
-                <h6><i class="fa fa-star event-future"></i> March 09-13, 2020</h6>
+                <h6><i class="fa fa-calendar"></i> March 09-13, 2020</h6>
                 <h2><a href="omero-users-workshop-tim-march-2020.html">OMERO Workshop, Munsingen</a></h2>
                 <p class="card-caption">Three three-hour workshops on how to use OMERO.</p>
             </div>
             <hr class="medium-8">
             <div class="small-12 medium-8 medium-offset-2 columns">
-                <h6><i class="fa fa-star event-future"></i> March 3-4, 2020</h6>
+                <h6><i class="fa fa-calendar"></i> March 3-4, 2020</h6>
                 <h2><a href="omero-users-workshop-paris-march-2020.html">OMERO Workshop, Paris</a></h2>
                 <p class="card-caption">A two-day workshop on how to use OMERO.</p>
             </div>


### PR DESCRIPTION
@lunson Removing the red starts from the two events in the Events list which signify that the events are in the future. Now, they are in the past.